### PR TITLE
Customize app for line link

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ The Makefile will build the firmware in a docker container and leave the binary 
 
 - Build
 
+   You should set `COIN` environment if you want to use a coin type other than the default ATOM.
+
    ```
-   make                # Builds the app
+   COIN=$COIN make                # Builds the app
    ```
 
 - Upload to a device

--- a/app/Makefile
+++ b/app/Makefile
@@ -55,10 +55,12 @@ endif
 
 $(info COIN  = [$(COIN)])
 
-ifeq ($(COIN),ATOM)
 # Main app configuration
-APPNAME = "Cosmos"
-APPPATH = "44'/118'"
+ifeq ($(COIN),ATOM)
+COIN_TYPE=118
+else
+ifeq ($(COIN),LN)
+COIN_TYPE=438
 else
 define error_message
 
@@ -69,6 +71,11 @@ COIN value not supported: [$(COIN)]
 endef
 $(error "$(error_message)")
 endif
+endif
+
+APPNAME="Cosmos"
+APPPATH="44'/$(COIN_TYPE)'"
+HDPATH_1_DEFAULT="(0x80000000u | "$(COIN_TYPE)"u)"
 
 APP_LOAD_PARAMS = --delete $(COMMON_LOAD_PARAMS) --path $(APPPATH)
 
@@ -171,7 +178,7 @@ endif
 #########################
 
 CC := $(CLANGPATH)clang
-CFLAGS += -O3 -Os -Wno-unknown-pragmas -Wno-unused-parameter
+CFLAGS += -O3 -Os -Wno-unknown-pragmas -Wno-unused-parameter -DHDPATH_1_DEFAULT=$(HDPATH_1_DEFAULT)
 
 AS := $(GCCPATH)arm-none-eabi-gcc
 AFLAGS +=
@@ -227,7 +234,7 @@ dep/%.d: %.c Makefile
 
 .PHONY: listvariants
 listvariants:
-	@echo VARIANTS COIN ATOM
+	@echo VARIANTS COIN ATOM LN
 
 .PHONY: version
 version:

--- a/app/Makefile
+++ b/app/Makefile
@@ -57,9 +57,11 @@ $(info COIN  = [$(COIN)])
 
 # Main app configuration
 ifeq ($(COIN),ATOM)
+APPNAME="Cosmos"
 COIN_TYPE=118
 else
 ifeq ($(COIN),LN)
+APPNAME="Link"
 COIN_TYPE=438
 else
 define error_message
@@ -73,7 +75,6 @@ $(error "$(error_message)")
 endif
 endif
 
-APPNAME="Cosmos"
 APPPATH="44'/$(COIN_TYPE)'"
 HDPATH_1_DEFAULT="(0x80000000u | "$(COIN_TYPE)"u)"
 
@@ -178,7 +179,7 @@ endif
 #########################
 
 CC := $(CLANGPATH)clang
-CFLAGS += -O3 -Os -Wno-unknown-pragmas -Wno-unused-parameter -DHDPATH_1_DEFAULT=$(HDPATH_1_DEFAULT)
+CFLAGS += -O3 -Os -Wno-unknown-pragmas -Wno-unused-parameter -DHDPATH_1_DEFAULT=$(HDPATH_1_DEFAULT) -DAPPNAME=$(APPNAME)
 
 AS := $(GCCPATH)arm-none-eabi-gcc
 AFLAGS +=

--- a/app/src/coin.h
+++ b/app/src/coin.h
@@ -39,7 +39,9 @@ typedef enum {
 #define VIEW_ADDRESS_OFFSET_SECP256K1       PK_LEN_SECP256K1
 #define VIEW_ADDRESS_LAST_PAGE_DEFAULT      0
 
-#define MENU_MAIN_APP_LINE1                "Cosmos"
+#define STRINGIFY(x) STRINGIFY_(x)
+#define STRINGIFY_(x) #x
+#define MENU_MAIN_APP_LINE1                STRINGIFY(APPNAME)
 #define MENU_MAIN_APP_LINE2                "Ready"
 #define APPVERSION_LINE1                   "Version:"
 #define APPVERSION_LINE2                   ("v" APPVERSION)

--- a/app/src/coin.h
+++ b/app/src/coin.h
@@ -24,7 +24,9 @@ extern "C" {
 #define HDPATH_LEN_DEFAULT   5
 
 #define HDPATH_0_DEFAULT     (0x80000000u | 0x2cu)
-#define HDPATH_1_DEFAULT     (0x80000000u | 0x76u)
+#ifndef HDPATH_1_DEFAULT
+#define HDPATH_1_DEFAULT     (0x80000000u | 0x1u)
+#endif // HDPATH_1_DEFAULT
 #define HDPATH_2_DEFAULT     (0x80000000u | 0u)
 #define HDPATH_3_DEFAULT     (0u)
 


### PR DESCRIPTION
This patch would:
- add a coin `LN` with its coin type 438'.
- add a build instruction for the custom coin type.